### PR TITLE
feat: モックサーバ切替用の changeToMockServer() を追加

### DIFF
--- a/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
+++ b/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
@@ -5,8 +5,20 @@ import FoundationNetworking
 #endif
 
 enum BaseURL {
-    static let origin = "https://isct.ex-tic.com"
-    static let host = "isct.ex-tic.com"
+    #if TEST
+    nonisolated(unsafe) static var origin = "https://extic-mock.titech.app"
+    nonisolated(unsafe) static var host = "extic-mock.titech.app"
+
+    static func changeToMockServer() {}
+    #else
+    nonisolated(unsafe) static var origin = "https://isct.ex-tic.com"
+    nonisolated(unsafe) static var host = "isct.ex-tic.com"
+
+    static func changeToMockServer() {
+        origin = "https://extic-mock.titech.app"
+        host = "extic-mock.titech.app"
+    }
+    #endif
 }
 
 enum LMSBaseURL {

--- a/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
+++ b/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
@@ -6,8 +6,8 @@ import FoundationNetworking
 
 enum BaseURL {
     #if TEST
-    nonisolated(unsafe) static var origin = "https://extic-mock.titech.app"
-    nonisolated(unsafe) static var host = "extic-mock.titech.app"
+    nonisolated(unsafe) static var origin = "https://extic-mock.isct.app"
+    nonisolated(unsafe) static var host = "extic-mock.isct.app"
 
     static func changeToMockServer() {}
     #else
@@ -15,8 +15,8 @@ enum BaseURL {
     nonisolated(unsafe) static var host = "isct.ex-tic.com"
 
     static func changeToMockServer() {
-        origin = "https://extic-mock.titech.app"
-        host = "extic-mock.titech.app"
+        origin = "https://extic-mock.isct.app"
+        host = "extic-mock.isct.app"
     }
     #endif
 }

--- a/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
+++ b/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
@@ -32,6 +32,13 @@ public struct ScienceTokyoPortal {
         self.httpClient = HTTPClientImpl(urlSession: urlSession, userAgent: userAgent)
     }
 
+    /// 接続先をモックサーバ (https://extic-mock.titech.app) に切り替える
+    /// 開発時のテストアカウントによるログイン経路用。
+    /// 一度呼ぶとプロセス終了まで mock URL に向き続ける。
+    public static func changeToMockServer() {
+        BaseURL.changeToMockServer()
+    }
+
     /// ScienceTokyoPortalにログイン
     /// - Parameter account: ログイン情報
     public func login(account: ScienceTokyoPortalAccount) async throws {

--- a/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
+++ b/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
@@ -32,7 +32,7 @@ public struct ScienceTokyoPortal {
         self.httpClient = HTTPClientImpl(urlSession: urlSession, userAgent: userAgent)
     }
 
-    /// 接続先をモックサーバ (https://extic-mock.titech.app) に切り替える
+    /// 接続先をモックサーバ (https://extic-mock.isct.app) に切り替える
     /// 開発時のテストアカウントによるログイン経路用。
     /// 一度呼ぶとプロセス終了まで mock URL に向き続ける。
     public static func changeToMockServer() {


### PR DESCRIPTION
## Summary
- ScienceTokyo SSO (Extic) の base URL を `https://extic-mock.titech.app` に切り替える `ScienceTokyoPortal.changeToMockServer()` を追加
- 既存の `TitechPortalKit.changeToMockServer()` と同じパターン (`nonisolated(unsafe) static var` + `#if TEST` 分岐)
- 開発時のテストアカウント (ScienceTokyo 側に test 用 SSO ログインがない) でログイン経路を通すため
- LMSBaseURL は今回触らない (LMS 側 mock は別ワーカー `t2schola-mock.titech.app` でカバー済み)

## Context
titechapp モノレポ側で `extic-mock/` という Cloudflare Workers パッケージを別途追加している (別 PR)。
このメソッドが使えるようになると、appleos クライアントの `Configuration.changeToDevServer()` から `ScienceTokyoPortal.changeToMockServer()` を呼べるようになる。

## Test plan
- [x] \`swift build\` がローカルで通ることを確認
- [ ] CI (build + test) を確認
- [ ] マージ後に titechapp モノレポ側で Package.resolved を更新して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)