### PR TITLE
feat: LMSBaseURL も changeToMockServer() の対象にする

### DIFF
--- a/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
+++ b/Sources/ScienceTokyoPortalKit/HTTP/HTTPRequest.swift
@@ -22,8 +22,20 @@ enum BaseURL {
 }
 
 enum LMSBaseURL {
-    static let origin = "https://lms.s.isct.ac.jp/2025/"
-    static let host = "lms.s.isct.ac.jp"
+    #if TEST
+    nonisolated(unsafe) static var origin = "https://extic-mock.isct.app/2025/"
+    nonisolated(unsafe) static var host = "extic-mock.isct.app"
+
+    static func changeToMockServer() {}
+    #else
+    nonisolated(unsafe) static var origin = "https://lms.s.isct.ac.jp/2025/"
+    nonisolated(unsafe) static var host = "lms.s.isct.ac.jp"
+
+    static func changeToMockServer() {
+        origin = "https://extic-mock.isct.app/2025/"
+        host = "extic-mock.isct.app"
+    }
+    #endif
 }
 
 enum HTTPMethod: String {

--- a/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
+++ b/Sources/ScienceTokyoPortalKit/ScienceTokyoPortalKit.swift
@@ -34,9 +34,11 @@ public struct ScienceTokyoPortal {
 
     /// 接続先をモックサーバ (https://extic-mock.isct.app) に切り替える
     /// 開発時のテストアカウントによるログイン経路用。
+    /// Extic SSO と LMS 双方を mock に向ける。
     /// 一度呼ぶとプロセス終了まで mock URL に向き続ける。
     public static func changeToMockServer() {
         BaseURL.changeToMockServer()
+        LMSBaseURL.changeToMockServer()
     }
 
     /// ScienceTokyoPortalにログイン


### PR DESCRIPTION
## Summary

- \`ScienceTokyoPortal.changeToMockServer()\` を呼んでも \`LMSBaseURL\` が \`let\` でハードコードされていたため、\`getLMSDashboard()\` / \`getLMSToken()\` が本番 LMS (\`lms.s.isct.ac.jp\`) に飛んでいた。
- \`LMSBaseURL\` も \`BaseURL\` と同じ規約で \`var\` + \`changeToMockServer()\` に変更し、\`ScienceTokyoPortal.changeToMockServer()\` から両方切り替えるようにした。

## Test plan

- [ ] \`swift test\` (ローカル PASS)
- [ ] CI

## 関連

- titechapp 側 (extic-mock) 改修: 本 PR と並行で extic-mock に LMS 3 endpoints を追加する PR を別途出す
- 1.5.0 として tag を切る予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)